### PR TITLE
Learn more page fix

### DIFF
--- a/workers-rights-app/components/RightsSheetContent.js
+++ b/workers-rights-app/components/RightsSheetContent.js
@@ -16,6 +16,9 @@ const RightsSheetContent = ({ learnMoreId }) => {
   const selectedLearnMore = ImportedData.getLearnMores().find(
     (learnmore) => learnmore.id === learnMoreId
   );
+  if (!selectedLearnMore) {
+    return null;
+  }
   const informationChunks = selectedLearnMore.informationChunks; //eslint-disable-line
   return (
     <View style={styles.container}>

--- a/workers-rights-app/screens/RightsDetailsScreen.js
+++ b/workers-rights-app/screens/RightsDetailsScreen.js
@@ -21,10 +21,7 @@ import ImportedData from "../data/FetchRightsData"; //eslint-disable-line
 const RightsDetailsScreen = ({ navigation }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [activeOrganizationId, setActiveOrganizationId] = useState("");
-  // Corresponds to lm1. Needs to be initialized with any garbage learnMore, otherwise app will crash because
-  const [activeLearnMoreId, setActiveLearnMoreId] = useState(
-    "-M7LY3fU0-iSv0HX94zB"
-  );
+  const [activeLearnMoreId, setActiveLearnMoreId] = useState("");
   const modalizeRef = useRef(null);
 
   // Get the parent subright
@@ -32,6 +29,7 @@ const RightsDetailsScreen = ({ navigation }) => {
   const parentSubRight = ImportedData.getSubRights().find(
     (subRight) => subRight.id === parentSubRightId
   );
+
   // Get list of LearnMore Ids to display. Works on empty array as well.
   const displayedLearnMoreIds = parentSubRight.learnMores
     ? parentSubRight.learnMores

--- a/workers-rights-app/screens/RightsDetailsScreen.js
+++ b/workers-rights-app/screens/RightsDetailsScreen.js
@@ -19,6 +19,14 @@ import ImportedData from "../data/FetchRightsData"; //eslint-disable-line
  */
 
 const RightsDetailsScreen = ({ navigation }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [activeOrganizationId, setActiveOrganizationId] = useState("");
+  // Corresponds to lm1. Needs to be initialized with any garbage learnMore, otherwise app will crash because
+  const [activeLearnMoreId, setActiveLearnMoreId] = useState(
+    "-M7LY3fU0-iSv0HX94zB"
+  );
+  const modalizeRef = useRef(null);
+
   // Get the parent subright
   const parentSubRightId = navigation.getParam("subrightId");
   const parentSubRight = ImportedData.getSubRights().find(
@@ -37,9 +45,6 @@ const RightsDetailsScreen = ({ navigation }) => {
           parentSubRight.organizations.includes(org.id)
         );
 
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [activeOrganizationId, setActiveOrganizationId] = useState("");
-
   const openModalHandler = (id) => {
     setIsModalOpen(true);
     setActiveOrganizationId(id);
@@ -48,12 +53,6 @@ const RightsDetailsScreen = ({ navigation }) => {
   const closeModalHandler = () => {
     setIsModalOpen(false);
   };
-
-  // Corresponds to lm1. Needs to be initialized with any garbage learnMore, otherwise app will crash because
-  const [activeLearnMoreId, setActiveLearnMoreId] = useState(
-    "-M7LY3fU0-iSv0HX94zB"
-  );
-  const modalizeRef = useRef(null);
 
   /*
    *
@@ -122,7 +121,11 @@ const RightsDetailsScreen = ({ navigation }) => {
       )}
 
       <Portal>
-        <Modalize ref={modalizeRef} modalStyle={styles.modalize}>
+        <Modalize
+          ref={modalizeRef}
+          modalStyle={styles.modalize}
+          modalTopOffset={50}
+        >
           <View style={styles.modalizeContent}>
             <RightsSheetContent learnMoreId={activeLearnMoreId} />
           </View>


### PR DESCRIPTION
Fixed the learnMore bottom sheet to now have a 50 px offset from the top of the page. This fixes the problem where on smaller iOS devices the bottom sheet was not dismissable. I also removed the need to have a junk LearnMoreID set as a state when initially opening the app. 