### PR TITLE
Fixed unique key issue for Organization Modals

### DIFF
--- a/workers-rights-app/components/RightsOrganizationModal.js
+++ b/workers-rights-app/components/RightsOrganizationModal.js
@@ -55,10 +55,12 @@ const RightsOrganizationModal = ({ id, isVisible, onCloseModal }) => {
 
           <View style={styles.description}>
             {selectedOrganization.description.map((desc) => (
-              <View style={styles.subheading}>
+              <View style={styles.subheading} key={desc.title}>
                 <Text style={styles.subtitle}>{desc.title}</Text>
                 {desc.data.map((line) => (
-                  <Text style={styles.info}>{line}</Text>
+                  <Text style={styles.info} key={line}>
+                    {line}
+                  </Text>
                 ))}
               </View>
             ))}


### PR DESCRIPTION
Fixed issue where opening on organization box would result in a warning that a unique key must be assigned to all items in a list.